### PR TITLE
adding new ListStreamKeyResponse type

### DIFF
--- a/LucidOcean.MultiChain/API/Stream.cs
+++ b/LucidOcean.MultiChain/API/Stream.cs
@@ -297,9 +297,9 @@ namespace LucidOcean.MultiChain.API
         /// <param name="start"></param>
         /// <param name="localOrdering"></param>
         /// <returns></returns>
-        public JsonRpcResponse<List<string>> ListStreamKeys(string streamName, List<string> keys, bool verbose = false, int count = int.MaxValue, int start = 0, bool localOrdering = false)
+        public JsonRpcResponse<List<ListStreamKeyResponse>> ListStreamKeys(string streamName, List<string> keys, bool verbose = false, int count = int.MaxValue, int start = 0, bool localOrdering = false)
         {
-            return _Client.Execute<List<string>>("liststreamkeys", 0, streamName, keys, verbose, count, start, localOrdering);
+            return _Client.Execute<List<ListStreamKeyResponse>>("liststreamkeys", 0, streamName, keys, verbose, count, start, localOrdering);
         }
 
         /// <summary>
@@ -312,9 +312,9 @@ namespace LucidOcean.MultiChain.API
         /// <param name="start"></param>
         /// <param name="localOrdering"></param>
         /// <returns></returns>
-        public Task<JsonRpcResponse<List<string>>> ListStreamKeysAsync(string streamName, List<string> keys, bool verbose = false, int count = int.MaxValue, int start = 0, bool localOrdering = false)
+        public Task<JsonRpcResponse<List<ListStreamKeyResponse>>> ListStreamKeysAsync(string streamName, List<string> keys, bool verbose = false, int count = int.MaxValue, int start = 0, bool localOrdering = false)
         {
-            return _Client.ExecuteAsync<List<string>>("liststreamkeys", 0, streamName, keys, verbose, count, start, localOrdering);
+            return _Client.ExecuteAsync<List<ListStreamKeyResponse>>("liststreamkeys", 0, streamName, keys, verbose, count, start, localOrdering);
         }
 
         /// <summary>

--- a/LucidOcean.MultiChain/Response/ListStreamKeyResponse.cs
+++ b/LucidOcean.MultiChain/Response/ListStreamKeyResponse.cs
@@ -1,0 +1,25 @@
+﻿/*=====================================================================
+Authors: Lucid Ocean PTY (LTD)
+Copyright © 2017 Lucid Ocean PTY (LTD). All Rights Reserved.
+
+License: Dual MIT / Lucid Ocean Wave Business License v1.0
+Please refer to http://www.lucidocean.co.za/wbl-license.html for restrictions and freedoms.
+The full license will also be found on the root of the main source-code directory.
+=====================================================================*/
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace LucidOcean.MultiChain.Response
+{
+    public class ListStreamKeyResponse
+    {
+
+        [JsonProperty("key")]
+        public string Key { get; set; }
+        [JsonProperty("items")]
+        public int Items { get; set; }
+        [JsonProperty("Confirmed")]
+        public int Confirmed { get; set; }
+
+    }
+}

--- a/MultiChainTests/StreamTests.cs
+++ b/MultiChainTests/StreamTests.cs
@@ -162,20 +162,20 @@ namespace MultiChainTests
         [TestMethod]
         public void ListStreamKeys()
         {
-            JsonRpcResponse<List<string>> response = null;
+            JsonRpcResponse<List<ListStreamKeyResponse>> response = null;
 
             List<string> list = new List<string>();
             list.Add("Item");
 
             response = _Client.Stream.ListStreamKeys("Lucid Ocean", list, true, 10, 1, true);
 
-            ResponseLogger<List<string>>.Log(response);
+            ResponseLogger<List<ListStreamKeyResponse>>.Log(response);
         }
 
         [TestMethod]
         public void ListStreamKeysAsync()
         {
-            JsonRpcResponse<List<string>> response = null;
+            JsonRpcResponse<List<ListStreamKeyResponse>> response = null;
             Task.Run(async () =>
             {
                 List<string> list = new List<string>();
@@ -184,7 +184,7 @@ namespace MultiChainTests
                 response = await _Client.Stream.ListStreamKeysAsync("Lucid Ocean", list, true, 10, 1, true);
             }).GetAwaiter().GetResult();
 
-            ResponseLogger<List<string>>.Log(response);
+            ResponseLogger<List<ListStreamKeyResponse>>.Log(response);
         }
 
         [TestMethod]


### PR DESCRIPTION
As per issue #24, ListStreamKeys was attempting to work with a List<string> return type, which wasn't deserializing. Added new Response type in line with other calls